### PR TITLE
Removing 2nd instance where Turbo was being included

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,6 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-import "@hotwired/turbo-rails"
 require("@rails/activestorage").start()
 require("channels")
 


### PR DESCRIPTION
In you `application.js` you were loading Turbo, but in your `app/views/layouts/application.html.erb` you already had the `turbo_include_tags` stuff.

I think that could have been what was breaking your devise form.

[Buy Me A Coffee if this helped](https://www.buymeacoffee.com/mikerogers0)